### PR TITLE
Cleanup processes for msc-wis2node-ui

### DIFF
--- a/msc-wis2node-ui/src/stores/useDataDistributionMetrics.js
+++ b/msc-wis2node-ui/src/stores/useDataDistributionMetrics.js
@@ -286,10 +286,16 @@ export const useDataDistributionMetrics = defineStore('metrics', () => {
     fileTotals.value = []
     sizeTotals.value = []
     await fetchFileList()
-
-    const latest = files.value[files.value.length - 1]
-    await fetchFile(latest)
+    if (files.value.length > 0) {
+      const latest = files.value[files.value.length - 1]
+      await fetchFile(latest)
+    }
   }
+
+  async function refreshDaily() {
+    await refresh()
+  }
+  setInterval(refreshDaily, 86400000)
 
   return {
     // state

--- a/msc-wis2node-ui/src/stores/useErrorMsg.js
+++ b/msc-wis2node-ui/src/stores/useErrorMsg.js
@@ -94,6 +94,24 @@ export const useErrorMsg = defineStore('errors', () => {
   }
   setInterval(incrementErrorMins, 60000)
 
+  function lessThanLimit(err) {
+    const currentTime = new Date()
+    const postedTime = new Date(err.time)
+    const timeDifference = currentTime - postedTime
+    return (timeDifference / (1000 * 60 * 60 * 24) <= 7)
+  }
+
+  function updateStoredErrorsHourly() {
+    // Need to remove errors older than 7 days
+    errorsList.value = errorsList.value.filter(lessThanLimit)
+    totalNumErrors.value = errorsList.value.length
+  }
+  setInterval(updateStoredErrorsHourly, 3600000)
+
+  function resetElapsedTimeDaily() {
+    totalElapsedTime.value = 0
+  }
+  setInterval(resetElapsedTimeDaily, 86400000)
   return {
     totalNumErrors,
     totalElapsedTime,

--- a/msc-wis2node-ui/src/stores/useNotifMsg.js
+++ b/msc-wis2node-ui/src/stores/useNotifMsg.js
@@ -17,7 +17,10 @@ const options = {
 export const useNotifMsg = defineStore('notifs', () => {
   // Values associated with the n-grid-items
   // notification statistics on Overview page
+  const totalMsgPerDay = ref([0, 0, 0, 0, 0, 0, 0])
+  const msgDateIndex = ref(0)
   const totalNumMsg = ref(0)
+  const numMsgCurrentDate = ref(0)
   const currMinNumMsg = ref(0)
   const avgMessages = ref(0)
   const timeUntilUpdate = ref(60)
@@ -43,6 +46,7 @@ export const useNotifMsg = defineStore('notifs', () => {
   notifClient.on('message', function () {
     currMinNumMsg.value = currMinNumMsg.value + 1
     totalNumMsg.value = totalNumMsg.value + 1
+    numMsgCurrentDate.value = numMsgCurrentDate.value + 1
   })
 
   // Update the msg/s value every min
@@ -69,11 +73,33 @@ export const useNotifMsg = defineStore('notifs', () => {
   }
   setInterval(countDown, 1000)
 
+  function updateMsgValuesDaily() {
+    if (msgDateIndex.value < 7) {
+      totalMsgPerDay.value[msgDateIndex.value] = numMsgCurrentDate.value
+      numMsgCurrentDate.value = 0
+      msgDateIndex.value = msgDateIndex.value + 1
+    } else {
+      // Ensure that only last 7 days data is kept
+      // Update totalMsgPerDay array and totalNumMsg
+      let newTotal = 0
+      for (let i=0; i<6; i++) {
+        totalMsgPerDay.value[i] = totalMsgPerDay.value[i+1]
+        newTotal = newTotal + totalMsgPerDay.value[i+1]
+      }
+      totalMsgPerDay.value[6] = numMsgCurrentDate.value
+      newTotal = newTotal + numMsgCurrentDate.value
+      totalNumMsg.value = newTotal
+      numMsgCurrentDate.value = 0
+    }
+  }
+  // Runs daily
+  setInterval(updateMsgValuesDaily, 86400000)
   return {
     totalNumMsg,
     currMinNumMsg,
     avgMessages,
     timeUntilUpdate,
     avgMsgChartData,
+    msgDateIndex
   }
 })

--- a/msc-wis2node-ui/src/views/wis2NodeOverview.vue
+++ b/msc-wis2node-ui/src/views/wis2NodeOverview.vue
@@ -14,7 +14,7 @@ import ActivityCharts from '../components/ActivityCharts.vue'
 import MetricFilesData from '@/components/MetricFilesData.vue'
 
 const notifsStore = useNotifMsg()
-const { avgMessages, timeUntilUpdate, totalNumMsg } = storeToRefs(notifsStore)
+const { avgMessages, timeUntilUpdate, totalNumMsg, msgDateIndex } = storeToRefs(notifsStore)
 
 const errorsStore = useErrorMsg()
 const { totalNumErrors, totalElapsedTime } = storeToRefs(errorsStore)
@@ -40,7 +40,9 @@ const brokerTopic = import.meta.env.VITE_TOPIC_NOTIFICATION
         <n-card>
           <n-text depth="3">Total messages</n-text>
           <div class="stat-value">{{ totalNumMsg }}</div>
-          <n-text depth="3">in the last {{ totalElapsedTime }} minutes</n-text>
+          <n-text depth="3" v-if="msgDateIndex === 0">in the last {{ totalElapsedTime }} minutes</n-text>
+          <n-text depth="3" v-else-if="msgDateIndex === 1">across the previous day and the last {{ totalElapsedTime }} minutes of today</n-text>
+          <n-text depth="3" v-else>across the previous {{ msgDateIndex }} days and in the last {{ totalElapsedTime }} minutes of today</n-text>
         </n-card>
       </n-grid-item>
 
@@ -58,7 +60,9 @@ const brokerTopic = import.meta.env.VITE_TOPIC_NOTIFICATION
         <n-card>
           <n-text depth="3">Dropped / Error Messages</n-text>
           <div class="stat-value">{{ totalNumErrors }}</div>
-          <n-text type="error">in the last {{ totalElapsedTime }} minutes</n-text>
+          <n-text type="error" v-if="msgDateIndex === 0">in the last {{ totalElapsedTime }} minutes</n-text>
+          <n-text type="error" v-else-if="msgDateIndex === 1">across the previous day and the last {{ totalElapsedTime }} minutes of today</n-text>
+          <n-text type="error" v-else>across the previous {{ msgDateIndex }} days and in the last {{ totalElapsedTime }} minutes of today</n-text>
         </n-card>
       </n-grid-item>
     </n-grid>


### PR DESCRIPTION
Adds processes to ensure only the last 7 days of error messages are stored. The total number of notification messages is tracked only for the last 7 days. Lastly, the displayed statistics of distribution metrics is refreshed at the end of the day.

CC @kngai 